### PR TITLE
Actualizacion enlace de navegacion

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Al finalizar este módulo deberás de tener:
 * [ ] [1.- Crear una cuenta de GitHub](#creando-una-cuenta-de-github)
 * [ ] [2.- Verificar la cuenta de GitHub](#verificar-la-cuenta-de-correo-en-github)
 * [ ] [3.- Ingresar a la Organización](#ingresar-a-la-organizacion)
-* [ ] [4.- Taller de Git y GitHub](taller-de-github-101)
+* [ ] [4.- Taller de Git y GitHub](#taller-de-github-101)
 
 
 ## Creando una cuenta de GitHub


### PR DESCRIPTION
El enlace de instrucciones que apunta a la sección del taller de Git y Github estaba roto, se corrigió para apuntar a la sección correspondiente